### PR TITLE
updating default seed

### DIFF
--- a/mchmm/_mc.py
+++ b/mchmm/_mc.py
@@ -308,7 +308,7 @@ class MarkovChain:
         seq[0] = _start
 
         # random seeds
-        r_states = np.random.randint(0, n, n) if seed is None else seed
+        r_states = np.random.randint(0, 999999, n) if seed is None else seed
 
         # simulation procedure
         for i in range(1, n):


### PR DESCRIPTION
Hi! Love the package, super useful :) 

I was testing it with some contrived probabilities with 5 states and found surprising results. I found this was due to the seeding. I was using n=20 so it was likely that for thousands of runs the seeds were the same resulting in weird results. The fix was to increase the "high" in numpy.random.randint. 

Lmk if you would prefer a different number or implementation. Thanks! 